### PR TITLE
Check for 'ERROR' response and end instead of timing out.

### DIFF
--- a/index.js
+++ b/index.js
@@ -67,7 +67,7 @@ Ecad.prototype._fetch = function(endpoint, fn) {
 
     client.on('data', function(chunk) {
         res.push(chunk);
-        if (~chunk.indexOf('END'))
+        if (~chunk.indexOf('END') || ~chunk.indexOf('ERROR'))
             client.end();
     });
 

--- a/test/ecad.test.js
+++ b/test/ecad.test.js
@@ -49,6 +49,13 @@ describe('Elasticache Auto Discovery', function() {
             expect(function() { throw hosts; })
               .to.throw(/No Elasticache hosts found/);
         });
+      it('should return error for ERROR memcached response', function() {
+        var ecad = new Ecad({endpoints: 'localhost:11211'});
+        var payload = 'ERROR';
+        var hosts = ecad._parse([payload]);
+        expect(function() { throw hosts; })
+            .to.throw(/Bad response from Elasticache./);
+      });
     });
 
     describe('#fetching', function() {


### PR DESCRIPTION
I hit this when pointing to memcached directly instead of elasticache.  This change just recognizes the 'ERROR' response and returns an error rather than having to hit the timeout.
